### PR TITLE
Update Card.vue

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -210,6 +210,6 @@ function __guard__ (value, transform) {
 </script>
 
 <style lang="sass">
-  @import "../scss/card";
+  @import "../scss/card"
 
 </style>


### PR DESCRIPTION
Fix error that occurred when upgrading to latest version of node(14.17.0) and node-sass (4.9.3): "Semicolons aren't allowed in the indented syntax."

Here is a screenshot of the error that I received before making this change (in case that is helpful):
<img width="1112" alt="Screen Shot 2021-05-30 at 9 34 05 PM" src="https://user-images.githubusercontent.com/4614468/120131856-d5b72b00-c18e-11eb-814a-84f141bdae96.png">